### PR TITLE
REST API for ENC

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+__pycache__
+venv
+deploy.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+#Based on https://github.com/ncsa/puppet-enc which is BSD-Licensed
+#
+#BSD 3-Clause License
+#
+#Copyright (c) 2023, NCSA
+#
+#Redistribution and use in source and binary forms, with or without
+#modification, are permitted provided that the following conditions are met:
+#
+#1. Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+#2. Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+#3. Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+#THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+#FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+#OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+FROM python:3.10.8
+
+WORKDIR /app
+EXPOSE 8080
+ENV PREFIX="/enc" \
+    PYTHONUNBUFFERED=1
+
+COPY requirements-rest.txt ./
+RUN pip install -r ./requirements-rest.txt
+
+COPY enc_azure_tags_rest.py ./
+COPY lib/ ./lib/
+CMD waitress-serve --url-prefix=${PREFIX} enc_azure_tags_rest:app

--- a/README.md
+++ b/README.md
@@ -21,9 +21,16 @@ To classify the nodes you must provision two tags into the Azure VM:
 * `puppet_environment`: Name of the environment for the VM. If not present defaults to `production`
 * `puppet_classes`: comma-separated list of Puppet classes that must be applied to this VM, e.g. `linux::base, role::mysql`. If not present defaults to empty (no classes)
 
-# Installation
+There are two flavours of this ENC:
 
-This process has to be done with the `puppet` user, or the user that runs the Puppet Server process
+* CLI Mode: runs as standalone command line application and can be used directly from Puppet Servers with Python installed
+* REST Mode: runs as a HTTP Server and can be called remotely
+
+# CLI Mode
+
+## Installation
+
+This process has to be done with the `puppet` user, or the user that runs the Puppet Server process in every Puppet Server node
 
 First, clone this repo into your Puppet Server node:
 
@@ -54,7 +61,7 @@ Or if your Service Principal password is stored in a Keyvault
 ```
 CONFIG = {
     "SERVICE_PRINCIPAL_CLIENT_ID": 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
-    "SERVICE_PRINCIPAL_CLIENT_SECRET": '*****************************',
+    "SERVICE_PRINCIPAL_TENANT_ID": 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy',
     "SERVICE_PRINCIPAL_CLIENT_SECRET_KEYVAULT": 'https://***.vault.azure.net/secrets/my-sp-password'
 }
 ```
@@ -77,7 +84,7 @@ Configure your Puppet Server's `puppet.conf` to use the ENC and restart it:
   external_nodes = /etc/puppetlabs/code/enc-azure-tags/enc-azure-tags
 ```
 
-# Testing
+## Testing
 
 Once you have completed the `Installation` steps, you can test the script manually running it with a FQDN:
 
@@ -90,6 +97,131 @@ environment: test
 ```
 
 If you don't have a Service Principal you can test the script without a `config.py` file and it will try to use you Azure CLI credentials. So you have to do `az login` beforehand.
+
+# REST Mode
+
+Based on [ncsa/puppet-enc](https://github.com/ncsa/puppet-enc/tree/main), it starts a Flask application which receives the requests from the ENC in Puppet Servers.
+
+## Configure Puppet Server
+
+First of all, copy the `enc-azure-rest` file to a location of your Puppet Server, e.g. `/etc/puppetlabs/code/enc-azure-tags/enc-azure-rest`, and be sure that it has execution permissions for the `puppet` user:
+
+```
+chmod +x /etc/puppetlabs/code/enc-azure-tags/enc-azure-rest
+```
+
+Be sure to modify `ENDPOINT` variable in `enc-azure-rest` to the endpoint where you are going to deploy the REST ENC server
+
+Configure your Puppet Server's `puppet.conf` to use the ENC REST client and restart it:
+
+```
+[master]
+  node_terminus = exec
+  external_nodes = /etc/puppetlabs/code/enc-azure-tags/enc-azure-rest
+```
+
+##  Deploy REST Mode on a server using Python
+
+First, clone this repo into any server:
+
+```
+$ cd /etc/puppetlabs/code
+$ git clone https://github.com/cpiment/enc-azure-tags
+$ cd enc-azure-tags
+``` 
+
+Then copy `config.py.SAMPLE` into `config.py`
+
+```
+$ cp config.py.SAMPLE config.py
+```
+
+Edit `config.py` and set the values with the credentials of the Service Principal
+
+```
+CONFIG = {
+    "SERVICE_PRINCIPAL_CLIENT_ID": 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+    "SERVICE_PRINCIPAL_CLIENT_SECRET": '*****************************',
+    "SERVICE_PRINCIPAL_TENANT_ID": 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy'
+}
+```
+
+Or if your Service Principal password is stored in a Keyvault
+
+```
+CONFIG = {
+    "SERVICE_PRINCIPAL_CLIENT_ID": 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+    "SERVICE_PRINCIPAL_TENANT_ID": 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy',
+    "SERVICE_PRINCIPAL_CLIENT_SECRET_KEYVAULT": 'https://***.vault.azure.net/secrets/my-sp-password'
+}
+```
+
+You can also specify an Azure Managed Identity ID to retrieve the password using `AZURE_CLIENT_ID` in the config.py file
+
+Create a python virtual environment named `venv`, activate it and install the required packages
+
+```
+$ python -m venv venv
+$ source venv/bin/activate
+$ pip install -r requirements-rest.txt
+```
+
+Start the REST server:
+
+```
+waitress-serve enc_azure_tags_rest:app
+```
+
+By default it will listen on any IP address of the server and port 8080
+
+### Testing
+
+Use `curl` to test:
+
+```
+curl http://localhost:8080/enc/hosts/mymachine.local
+```
+
+## Deploy REST Mode on a server using Docker/Podman
+
+I have used `podman` but you can use the same commands with `docker`
+
+First, clone this repo into any server with `docker` or `podman`:
+
+```
+$ cd /etc/puppetlabs/code
+$ git clone https://github.com/cpiment/enc-azure-tags
+$ cd enc-azure-tags
+``` 
+
+Build the image
+
+```
+podman build -t enc-azure-tags-rest:1.0 .
+```
+
+Run the image using the necessary environment variables, e.g.:
+
+```
+podman run \
+  -p 8080:8080 \
+  --name enc-azure-tags \
+  --rm \
+  --env SERVICE_PRINCIPAL_CLIENT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
+  --env SERVICE_PRINCIPAL_TENANT_ID='yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy' \
+  --env SERVICE_PRINCIPAL_CLIENT_SECRET_KEYVAULT=https://***.vault.azure.net/secrets/my-sp-password \
+  enc-azure-tags-rest:1.0
+```
+
+You can specify `SERVICE_PRINCIPAL_CLIENT_SECRET` instead of retrieving it from a Key Vault
+
+### Testing
+
+Use `curl` to test:
+
+```
+curl http://localhost:8080/enc/hosts/mymachine.local
+```
 
 # Contributing
 

--- a/enc-azure-rest
+++ b/enc-azure-rest
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+CURRENTDIR=$(dirname $0)
+ENDPOINT=http://localhost:8080
+curl -s ${ENDPOINT}/enc/hosts/$1

--- a/enc-azure-tags.py
+++ b/enc-azure-tags.py
@@ -1,9 +1,7 @@
 """ENC that generates environment and puppet classes from Azure Tags of the VM"""
 
 import sys
-from lib.credential import Credential
-from azure.mgmt.resource import SubscriptionClient
-from azure.mgmt.resource import ResourceManagementClient
+from lib.vm_classifier import VMClassifier
 import yaml
 
 # This dumper modifies 'null' with blanks to ensure Puppet-compatible YAML format
@@ -15,46 +13,22 @@ yaml.SafeDumper.add_representer(
 # There must be one parameter. If there are more, the rest are ignored
 if len(sys.argv) < 2:
     sys.exit(1)
- 
+
+# Init the VM Classifier
+classifier = VMClassifier()
+
 # Received parameter is FQDN of the host as stored by Puppet
 node_fqdn = sys.argv[1]
 
-# Store the shortname of the host
-node_shortname = node_fqdn.split(".")[0].lower()
+# Classify the VM
+output = classifier.classify(node_fqdn)
 
-# Login into Azure using Service Principal credentials from config.py
-credential = Credential().get()
+if output is not None:
+    # Dump the information as YAML to standard output
+    yaml.safe_dump(output, sys.stdout,default_flow_style=False)
 
-# Get all subscription IDs visible by the Service Principal
-subscription_ids = [x.subscription_id for x in SubscriptionClient(credential).subscriptions.list()]
-
-# Search the VM in every subscription
-for id in subscription_ids:
-    resource_management_client = ResourceManagementClient(credential,id)    
-    # We search the VMs which name contains the Puppet Node shortname
-    filtered_vms = resource_management_client.resources.list(
-        filter = f"substringOf('{node_shortname}',name) and resourceType eq 'Microsoft.Compute/virtualMachines'"
-    )
-    # If there is one VM in the list
-    for vm in filtered_vms:
-        # We store the values from puppet_environment and puppet_classes tags
-        environment = vm.tags['puppet_environment'] if 'puppet_environment' in vm.tags else None
-        classes = vm.tags['puppet_classes'].split(",") if 'puppet_classes' in vm.tags else []
-        # Prepare the output dict with default values
-        output = {
-            'classes':None, 
-            'environment': environment if environment is not None else 'production'
-        }
-        # Store each class as a dict key with None value
-        for cl in classes:
-            if output['classes'] is None:
-                output['classes'] = {}
-            output['classes'][cl.strip()]=None
-        # Dump the information as YAML to standard output
-        yaml.safe_dump(output, sys.stdout,default_flow_style=False)
-
-        # Return 0 code (OK)
-        sys.exit(0)
+    # Return 0 code (OK)
+    sys.exit(0)
 
 # If we reach this, no VM has been found in Azure, return 1 code (ERROR)
 sys.exit(1)

--- a/enc_azure_tags_rest.py
+++ b/enc_azure_tags_rest.py
@@ -1,0 +1,69 @@
+""" Based on https://github.com/ncsa/puppet-enc which is BSD-Licensed
+
+BSD 3-Clause License
+
+Copyright (c) 2023, NCSA
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+from flask import Flask, request, abort, Response
+import yaml
+from lib.vm_classifier import VMClassifier
+
+# Init the VM Classifier
+classifier = VMClassifier()
+
+app = Flask(__name__)
+
+# This dumper modifies 'null' with blanks to ensure Puppet-compatible YAML format
+yaml.SafeDumper.add_representer(
+    type(None),
+    lambda dumper, value: dumper.represent_scalar(u'tag:yaml.org,2002:null', '')
+  )
+
+def make_response(data):
+    """Create yaml response."""
+    if data:
+        resp = Response(response=yaml.safe_dump(data,default_flow_style=False), status=200,  mimetype="text/yaml")
+    else:
+        resp = Response(response="", status=200, mimetype="text/yaml")
+    # resp.headers['Access-Control-Allow-Origin'] = '*'
+    return resp
+
+@app.route("/healthz")
+def root():
+    return "OK"
+
+@app.route("/hosts/<fqdn>", methods=['GET'])
+def get_host(fqdn):
+    host = classifier.classify(fqdn)
+    if host is not None:
+        return make_response(host)
+
+    return make_response(None)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/lib/vm_classifier.py
+++ b/lib/vm_classifier.py
@@ -1,0 +1,40 @@
+from lib.credential import Credential
+from azure.mgmt.resource import SubscriptionClient
+from azure.mgmt.resource import ResourceManagementClient
+
+class VMClassifier(object):
+
+    def __init__(self):
+        # Login into Azure using Service Principal credentials from config.py
+        self._credential = Credential().get()
+        # Get all subscription IDs visible by the Service Principal
+        self._subscription_ids = [x.subscription_id for x in SubscriptionClient(self._credential).subscriptions.list()]
+
+    def classify(self,fqdn: str):
+        node_shortname = fqdn.split(".")[0].lower()
+        # Search the VM in every subscription
+        for id in self._subscription_ids:
+            resource_management_client = ResourceManagementClient(self._credential,id)    
+            # We search the VMs which name contains the Puppet Node shortname
+            filtered_vms = resource_management_client.resources.list(
+                filter = f"substringOf('{node_shortname}',name) and resourceType eq 'Microsoft.Compute/virtualMachines'"
+            )
+            # If there is one VM in the list
+            for vm in filtered_vms:
+                # We store the values from puppet_environment and puppet_classes tags
+                environment = vm.tags['puppet_environment'] if 'puppet_environment' in vm.tags else None
+                classes = vm.tags['puppet_classes'].split(",") if 'puppet_classes' in vm.tags else []
+                # Prepare the output dict with default values
+                output = {
+                    'classes':None, 
+                    'environment': environment if environment is not None else 'production'
+                }
+                # Store each class as a dict key with None value
+                for cl in classes:
+                    if output['classes'] is None:
+                        output['classes'] = {}
+                    output['classes'][cl.strip()]=None
+                
+                return output
+            
+        return None

--- a/requirements-rest.txt
+++ b/requirements-rest.txt
@@ -1,0 +1,6 @@
+azure-identity
+azure-mgmt-resource
+azure-keyvault-secrets
+pyyaml
+flask
+waitress


### PR DESCRIPTION
With this change the ENC can be hosted outside the Puppet Servers and the Puppet Servers can call a remote endpoint to classify the nodes